### PR TITLE
Added get_keyword_tag to supported xrpc methods.

### DIFF
--- a/lib/robotremote.js
+++ b/lib/robotremote.js
@@ -49,6 +49,7 @@ function Server(libraries, options, listeningCallback) {
     this.server.on('run_keyword', rpcWrap(this.runKeyword));
     this.server.on('get_keyword_arguments', rpcWrap(this.getKeywordArguments));
     this.server.on('get_keyword_documentation', rpcWrap(this.getKeywordDocumentation));
+    this.server.on('get_keyword_tags', rpcWrap(this.getKeywordTags));
 
     // Register signal handlers.
     var handleSignal = function () {
@@ -69,6 +70,9 @@ Server.prototype.getKeywordDocumentation = function (name, response) {
     response(null, this.keywords[name].doc);
 };
 
+Server.prototype.getKeywordTags = function (name, response) {
+  response(null, this.keywords[name].tags);
+};
 Server.prototype.getKeywordArguments = function (name, response) {
     response(null, this.keywords[name].args);
 };

--- a/test/testlibrary.js
+++ b/test/testlibrary.js
@@ -7,6 +7,7 @@ var lib = module.exports;
 
 lib.doNothing = function () {
 };
+lib.doNothing.tags = ["tag1", "tag2"];
 
 lib.concatenateArguments = function (arg1, arg2) {
     return arg1 + arg2;


### PR DESCRIPTION
get_keyword_tag was required for me to get the tests passing. I am using Python version 3.6.2 and Robot version 3.0.2. Without this xrpc method, Robot was failing to load any of the remote keywords.