### PR TITLE
Added check for undefined keyword in getKeywordDocumentation method. …

### DIFF
--- a/lib/robotremote.js
+++ b/lib/robotremote.js
@@ -67,7 +67,14 @@ function Server(libraries, options, listeningCallback) {
 module.exports.Server = Server;
 
 Server.prototype.getKeywordDocumentation = function (name, response) {
-    response(null, this.keywords[name].doc);
+    /*
+       Checking for existence of keyword because Robot will send some
+       meta keywords, such as __init__ and __intro__, for the purposes
+       of generating documentation. Return '' if the client has not supplied
+       definitions for these meta keywords.
+   */
+    var keyword = this.keywords[name];
+    response(null, !!keyword ? keyword.doc : '');
 };
 
 Server.prototype.getKeywordTags = function (name, response) {


### PR DESCRIPTION
…Robot sends some meta-keywords such as __init__ and __intro__ that the client may not have defined. Return '' if the client did not supply definitions for these meta-keywords. (Before this change, server was terminating when trying to execute libdoc command against it: python -m robot.libdoc --name MyLibrary Remote::http://localhost:8270 MyLibrary.xml)