### PR TITLE
Fixed "Calling dynamic method 'get_keyword_tags' failed" on RF 3.2

### DIFF
--- a/lib/robotremote.js
+++ b/lib/robotremote.js
@@ -71,7 +71,7 @@ Server.prototype.getKeywordDocumentation = function (name, response) {
 };
 
 Server.prototype.getKeywordTags = function (name, response) {
-    response(null, this.keywords[name].tags);
+    response(null, this.keywords[name].tags || []);
 };
 
 Server.prototype.getKeywordArguments = function (name, response) {


### PR DESCRIPTION
Fixed the error using the latest Robot Framework 3.2:
"Calling dynamic method 'get_keyword_tags' failed: value must be a list of strings"
(in case no tags are manually set in the custom functions).
Thanks, L