### PR TITLE
Added support for keywords with variable arguments and named arguments

### DIFF
--- a/lib/robotremote.js
+++ b/lib/robotremote.js
@@ -53,7 +53,15 @@ function Server(libraries, options, listeningCallback) {
     var that = this;
     var rpcWrap = function (keyword) {
         return function (method, params, response) {
-            params.push(response);
+            // Normally params is an array with the function name and an array of parameters
+            // In case of named arguments (kwargs), params contains three items, the last one contains the 
+            // named arguments. In that case build a proper kwargs object.
+            if (typeof params[2] === "object") {
+                params[1].push(params[2]);
+                params[2] = response;
+            } else {
+                params.push(response);
+            }
             keyword.apply(that, params);
         };
     };

--- a/test/robotremote.robot
+++ b/test/robotremote.robot
@@ -20,6 +20,18 @@ Run Synchronous Keyword With Return Value And Multiple Arguments
     ${result}=    Concatenate Arguments    Bau    Miao
     Should Be Equal    ${result}    BauMiao
 
+Run Synchronous Keyword With Return Value And Variable Arguments
+    ${result}=    Concatenate Arguments With Var Arguments    prefix   One  Two
+    Should Be Equal    ${result}    prefix["One","Two"]
+
+Run Synchronous Keyword With Return Value And Named Arguments
+    ${result}=    Concatenate Arguments With Named Arguments    prefix   a=1   b=${2}
+    Should Be Equal    ${result}    prefix{"a":"1","b":2}
+
+Run Synchronous Keyword With Return Value And Both Named and Variable Arguments
+    ${result}=    Concatenate Arguments With Var And Named Arguments    prefix   One    Two   a=1   b=${2}
+    Should Be Equal    ${result}    prefix["One","Two",{"a":"1","b":2}]
+
 Run Synchronous Failing Keyword
     Run Keyword And Expect Error    Error    Just Fail
 
@@ -30,6 +42,18 @@ Run Asynchronous Keyword Without Return Value And No Arguments
 Run Asynchronous Keyword With Return Value And Multiple Arguments
     ${result}=    Concatenate Arguments Async    Bau    Miao
     Should Be Equal    ${result}    BauMiao
+
+Run Asynchronous Keyword With Return Value And Variable Arguments
+    ${result}=    Concatenate Arguments With Var Arguments Async    prefix   One  Two
+    Should Be Equal    ${result}    prefix["One","Two"]
+
+Run Aynchronous Keyword With Return Value And Named Arguments
+    ${result}=    Concatenate Arguments With Named Arguments Async    prefix   a=1   b=${2}
+    Should Be Equal    ${result}    prefix{"a":"1","b":2}
+
+Run Asynchronous Keyword With Return Value And Both Named and Variable Arguments
+    ${result}=    Concatenate Arguments With Var And Named Arguments Async    prefix   One    Two   a=1   b=${2}
+    Should Be Equal    ${result}    prefix["One","Two",{"a":"1","b":2}]
 
 Run Asynchronous Failing Keyword
     Run Keyword And Expect Error    Error    Just Fail Async

--- a/test/testlibrary.js
+++ b/test/testlibrary.js
@@ -17,6 +17,23 @@ lib.concatenateArgumentsWithCommentsInArgs = function (arg1, arg2 /*, skipped ar
     return arg1 + arg2;
 };
 
+lib.concatenateArgumentsWithVarArguments = function (prefix, ...args) {
+    return prefix + JSON.stringify(args);
+};
+lib.concatenateArgumentsWithVarArguments.args = ['prefix', '*args'];
+
+lib.concatenateArgumentsWithNamedArguments = function (prefix, kwargs) {
+    return prefix + JSON.stringify(kwargs);
+};
+lib.concatenateArgumentsWithNamedArguments.args = ['prefix', '**kwargs'];
+
+// For language constraints, var arguments should be declared at the end, so the last
+// args will be kwargs
+lib.concatenateArgumentsWithVarAndNamedArguments = function (prefix, ...args) {
+    return prefix + JSON.stringify(args);
+};
+lib.concatenateArgumentsWithVarAndNamedArguments.args = ['prefix', '*args', '**kwargs'];
+
 lib.justFail = function () {
     throw new Error();
 };
@@ -32,6 +49,29 @@ lib.concatenateArgumentsAsync = function (arg1, arg2) {
         resolve(arg1 + arg2);
     });
 };
+
+lib.concatenateArgumentsWithVarArgumentsAsync = function (prefix, ...args) {
+    return new Promise(function (resolve) {
+        resolve(prefix + JSON.stringify(args));
+    });
+};
+lib.concatenateArgumentsWithVarArgumentsAsync.args = ['prefix', '*args'];
+
+lib.concatenateArgumentsWithNamedArgumentsAsync = function (prefix, kwargs) {
+    return new Promise(function (resolve) {
+        resolve(prefix + JSON.stringify(kwargs));
+    });
+};
+lib.concatenateArgumentsWithNamedArgumentsAsync.args = ['prefix', '**kwargs'];
+
+// For language constraints, var arguments should be declared at the end, so the last
+// args will be kwargs
+lib.concatenateArgumentsWithVarAndNamedArgumentsAsync = function (prefix, ...args) {
+    return new Promise(function (resolve) {
+        resolve(prefix + JSON.stringify(args));
+    });
+};
+lib.concatenateArgumentsWithVarAndNamedArgumentsAsync.args = ['prefix', '*args', '**kwargs'];
 
 lib.justFailAsync = function () {
     return new Promise(function (resolve, reject) {


### PR DESCRIPTION
Added support for varargs and kwargs.
Requires manual filling of "args" when defining a JS function. It would be great to use some type of annotation (Typescript or https://medium.com/google-developers/exploring-es7-decorators-76ecb65fb841)
However, in the meantime it will be OK to manual fill the argument type like in the test library.
Tests updated.

This branch is based on the https://github.com/comick/node-robotremoteserver/pull/8 and it is required to pass 'args' as function annotation.

Thanks, L